### PR TITLE
Use separate networks in Traefik example

### DIFF
--- a/examples/compose/compose.traefik.yml
+++ b/examples/compose/compose.traefik.yml
@@ -27,6 +27,7 @@ services:
     restart: "on-failure"
     networks:
       - "cetusguard"
+      - "public"
     ports:
       - "127.0.0.1:3000:3000/tcp"
       - "127.0.0.1:8080:8080/tcp"
@@ -34,7 +35,7 @@ services:
       - "--api.insecure=true"
       - "--api.dashboard=true"
       - "--providers.docker.endpoint=tcp://cetusguard:2375"
-      - "--providers.docker.network=cetusguard"
+      - "--providers.docker.network=public"
       - "--providers.docker.exposedbydefault=false"
       - "--entrypoints.traefik.address=:3000/tcp"
       - "--entrypoints.whoami.address=:8080/tcp"
@@ -44,7 +45,7 @@ services:
     image: "docker.io/traefik/whoami:latest"
     restart: "on-failure"
     networks:
-      - "cetusguard"
+      - "public"
     labels:
       traefik.enable: "true"
       traefik.http.routers.whoami.rule: "PathPrefix(`/`)"
@@ -56,3 +57,5 @@ networks:
 
   cetusguard:
     name: "cetusguard"
+  public:
+    name: "public"


### PR DESCRIPTION
The whole point of using a Docker socket proxy like CetusGuard is to limit access to the Docker socket. The main purpose of Traefik is exposing HTTP/TCP/UDP services to the public. Such services must share a network with Traefik to be discovered and routed to, but this must not be a network with the Docker socket proxy. Only services which actually needs access to the Docker socket must be in such a network, in this case only Traefik.